### PR TITLE
Add valid inputs to new Blob() to typings

### DIFF
--- a/js-file-download.d.ts
+++ b/js-file-download.d.ts
@@ -1,5 +1,7 @@
-declare module "js-file-download" {
-
-    export default function fileDownload(data: string, filename: string, mime?:string): void;
-    
+declare module 'js-file-download' {
+    export default function fileDownload(
+        data: string | ArrayBuffer | ArrayBufferView | Blob,
+        filename: string,
+        mime?: string
+    ): void;
 }


### PR DESCRIPTION
According to MDN, the first argument to `new Blob()` is "an Array
of ArrayBuffer, ArrayBufferView, Blob, DOMString objects, or a
mix of any of such objects" [[1]]. We use `Blob` as an input in our
project, and the new type definitions don't work all that well for
us. This commit updates the type definitions to allow all valid inputs
to `new Blob()` as valid types in the function signature.

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob