### PR TITLE
Add eslint as a mimimal form of testing for CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "commonjs": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
-
+  - "8.12.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Javascript function that triggers browser to save javascript-generated content to a file",
   "main": "file-download.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint file-download.js",
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -22,5 +23,8 @@
     "url": "https://github.com/kennethjiang/js-file-download/issues"
   },
   "homepage": "https://github.com/kennethjiang/js-file-download",
-  "typings": "js-file-download.d.ts"
+  "typings": "js-file-download.d.ts",
+  "devDependencies": {
+    "eslint": "^5.8.0"
+  }
 }


### PR DESCRIPTION
I noticed the project had Travis set up, but no tests to run (making Travis fail each build). 

This PR adds ESLint as a devtool. Linting != testing, but at least ESLint can help catch some errors through static analysis of the code.