### PR TITLE
fix bug window.URL.createObjectURL is not a function

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -2,30 +2,30 @@ module.exports = function(data, filename, mime, bom) {
     var blobData = (typeof bom !== 'undefined') ? [bom, data] : [data]
     var blob = new Blob(blobData, {type: mime || 'application/octet-stream'});
     if (typeof window.navigator.msSaveBlob !== 'undefined') {
-        // IE workaround for "HTML7007: One or more blob URLs were 
-        // revoked by closing the blob for which they were created. 
-        // These URLs will no longer resolve as the data backing 
+        // IE workaround for "HTML7007: One or more blob URLs were
+        // revoked by closing the blob for which they were created.
+        // These URLs will no longer resolve as the data backing
         // the URL has been freed."
         window.navigator.msSaveBlob(blob, filename);
     }
     else {
-        var blobURL = window.URL.createObjectURL(blob);
+        var blobURL = (window.URL ? window.URL : window.webkitURL).createObjectURL(blob);
         var tempLink = document.createElement('a');
         tempLink.style.display = 'none';
         tempLink.href = blobURL;
-        tempLink.setAttribute('download', filename); 
-        
+        tempLink.setAttribute('download', filename);
+
         // Safari thinks _blank anchor are pop ups. We only want to set _blank
         // target if the browser does not support the HTML5 download attribute.
-        // This allows you to download files in desktop safari if pop up blocking 
+        // This allows you to download files in desktop safari if pop up blocking
         // is enabled.
         if (typeof tempLink.download === 'undefined') {
             tempLink.setAttribute('target', '_blank');
         }
-        
+
         document.body.appendChild(tempLink);
         tempLink.click();
-        
+
         // Fixes "webkit blob resource error 1"
         setTimeout(function() {
             document.body.removeChild(tempLink);


### PR DESCRIPTION
fix bug window.URL.createObjectURL is not a function on Chrome