### PR TITLE
fix bug window.URL.createObjectURL is not a function on 360se

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -9,7 +9,7 @@ module.exports = function(data, filename, mime, bom) {
         window.navigator.msSaveBlob(blob, filename);
     }
     else {
-        var blobURL = (window.URL ? window.URL : window.webkitURL).createObjectURL(blob);
+        var blobURL = window.URL && window.URL.createObjectURL(blob) ? window.URL.createObjectURL(blob) : window.webkitURL.createObjectURL(blob);
         var tempLink = document.createElement('a');
         tempLink.style.display = 'none';
         tempLink.href = blobURL;


### PR DESCRIPTION
on 360 safe explorers, window.URL is a string, and exits the window.webkitURL 