### PR TITLE
fix bug window.URL.createObjectURL is not a function on 360 safe explore

### DIFF
--- a/file-download.js
+++ b/file-download.js
@@ -9,7 +9,7 @@ module.exports = function(data, filename, mime, bom) {
         window.navigator.msSaveBlob(blob, filename);
     }
     else {
-        var blobURL = (window.URL ? window.URL : window.webkitURL).createObjectURL(blob);
+        var blobURL = window.URL && window.URL.createObjectURL(blob) ? window.URL.createObjectURL(blob) : window.webkitURL.createObjectURL(blob);
         var tempLink = document.createElement('a');
         tempLink.style.display = 'none';
         tempLink.href = blobURL;

--- a/file-download.js
+++ b/file-download.js
@@ -9,7 +9,7 @@ module.exports = function(data, filename, mime, bom) {
         window.navigator.msSaveBlob(blob, filename);
     }
     else {
-        var blobURL = window.URL && window.URL.createObjectURL(blob) ? window.URL.createObjectURL(blob) : window.webkitURL.createObjectURL(blob);
+        var blobURL = window.URL && window.URL.createObjectURL ? window.URL.createObjectURL(blob) : window.webkitURL.createObjectURL(blob);
         var tempLink = document.createElement('a');
         tempLink.style.display = 'none';
         tempLink.href = blobURL;


### PR DESCRIPTION
on 360 safe explore, window,URL is a string, and the function window.webkitURL is exists