### PR TITLE
fix .d.ts  bom argument also accepts Uint8Array

### DIFF
--- a/js-file-download.d.ts
+++ b/js-file-download.d.ts
@@ -3,6 +3,6 @@ declare module 'js-file-download' {
         data: string | ArrayBuffer | ArrayBufferView | Blob,
         filename: string,
         mime?: string,
-        bom?: string
+        bom?: string | Uint8Array
     ): void;
 }


### PR DESCRIPTION
Bom is part of blob-data and we may want to call it like this

```js
fileDownload(
    csv,
    `utf8-bom-flagged.csv`,
    "text/csv",
    new Uint8Array([0xef, 0xbb, 0xbf])
)
```

- [Byte order mark - Wikipedia](https://en.wikipedia.org/wiki/Byte_order_mark#cite_note-b-13)
